### PR TITLE
Add local S3 service and API key generator

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+services:
+  ncat:
+    image: stephengpope/no-code-architects-toolkit:latest
+    ports:
+      - "8080:8080"
+    environment:
+      API_KEY: your_api_key
+      S3_ENDPOINT_URL: http://minio:9000
+      S3_ACCESS_KEY: minioadmin
+      S3_SECRET_KEY: minioadmin
+      S3_BUCKET_NAME: ncat-bucket
+      S3_REGION: us-east-1
+      LOCAL_STORAGE_PATH: /tmp
+      MAX_QUEUE_LENGTH: 10
+      GUNICORN_WORKERS: 4
+      GUNICORN_TIMEOUT: 300
+    depends_on:
+      - minio
+
+  minio:
+    image: minio/minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    volumes:
+      - minio_data:/data
+    command: server /data --console-address ":9001"
+
+volumes:
+  minio_data:

--- a/generate_api_key.py
+++ b/generate_api_key.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Generate a random API key."""
+import secrets
+import string
+import sys
+
+
+def generate(length: int = 64) -> str:
+    """Return a cryptographically secure random string."""
+    alphabet = string.ascii_letters + string.digits
+    return ''.join(secrets.choice(alphabet) for _ in range(length))
+
+
+if __name__ == "__main__":
+    length = int(sys.argv[1]) if len(sys.argv) > 1 else 64
+    print(generate(length))


### PR DESCRIPTION
## Summary
- connect `ncat` container to an included Minio service
- add a helper script to generate secure API keys

## Testing
- `pytest -q` *(fails: command not found)*