### PR TITLE
Add Docker build configuration for NCAT

### DIFF
--- a/Dockerfile.minio
+++ b/Dockerfile.minio
@@ -1,0 +1,11 @@
+FROM minio/minio:latest
+
+# Default root credentials (can be overridden at runtime)
+ENV MINIO_ROOT_USER=minioadmin
+ENV MINIO_ROOT_PASSWORD=minioadmin
+
+# Expose API and console ports
+EXPOSE 9000 9001
+
+# Run MinIO server with console enabled
+CMD ["server", "/data", "--console-address", ":9001"]

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Each endpoint is supported by robust payload validation and detailed API documen
 ### Run the Docker Container:
 
    ```bash
-   docker run -d -p 8080:8080 \
+   docker run -d -p 8081:8081 \
      # Authentication (required)
      -e API_KEY=your_api_key \
      

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,12 @@
 version: '3.8'
 services:
   ncat:
-    image: stephengpope/no-code-architects-toolkit:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: no-code-architects-toolkit
     ports:
-      - "8080:8080"
+      - "8081:8081"
     environment:
       API_KEY: your_api_key
       S3_ENDPOINT_URL: http://minio:9000
@@ -19,7 +22,9 @@ services:
       - minio
 
   minio:
-    image: minio/minio
+    build:
+      context: .
+      dockerfile: Dockerfile.minio
     ports:
       - "9000:9000"
       - "9001:9001"


### PR DESCRIPTION
## Summary
- build the NCAT image from the repo's Dockerfile
- map port 8081 to the container
- update README example to use port 8081

## Testing
- `pytest -q` *(fails: command not found)*