### PR TITLE
Add env sample and update compose

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,23 @@
+# Sample environment variables for No-Code Architects Toolkit
+
+# API authentication
+API_KEY=your_api_key
+
+# S3 compatible storage configuration
+S3_ENDPOINT_URL=http://minio:9000
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+S3_BUCKET_NAME=ncat-bucket
+S3_REGION=us-east-1
+
+# Optional Google Cloud Storage configuration
+GCP_SA_CREDENTIALS=
+GCP_BUCKET_NAME=
+
+# Local storage path for temporary files
+LOCAL_STORAGE_PATH=/tmp
+
+# Performance tuning
+MAX_QUEUE_LENGTH=10
+GUNICORN_WORKERS=4
+GUNICORN_TIMEOUT=300

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Repository Guidelines
+
+This project contains the No-Code Architects Toolkit API implemented in Python and packaged with Docker.
+
+## Development
+- Ensure basic Python syntax checks pass before committing:
+  ```bash
+  python -m py_compile $(git ls-files '*.py')
+  ```
+- The Docker image for `ncat` is built locally; running `docker compose pull` will fail. Use `docker compose build` to build images.
+
+## Docker
+- `docker-compose.yml` defines two services: `ncat` and `minio`.
+- Start services with:
+  ```bash
+  docker compose up -d
+  ```
+
+## Environment
+- Copy `.env.sample` to `.env` and adjust values for local development.
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   ncat:
     build:


### PR DESCRIPTION
## Summary
- add `.env.sample` for reference environment variables
- document repository guidelines in new `AGENTS.md`
- remove deprecated version from `docker-compose.yml`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `docker compose build ncat` *(fails: `docker: command not found`)*