### PR TITLE
Fix missing variable reference

### DIFF
--- a/routes/v1/toolkit/job_status.py
+++ b/routes/v1/toolkit/job_status.py
@@ -44,6 +44,7 @@ def get_job_status(job_id, data):
     get_job_id = data.get('job_id')
 
     logger.info(f"Retrieving status for job {get_job_id}")
+    endpoint = "/v1/toolkit/job/status"
     
     try:
         # Construct the path to the job status file
@@ -58,8 +59,8 @@ def get_job_status(job_id, data):
             job_status = json.load(file)
         
         # Return the job status file content directly
-        return job_status, "/v1/toolkit/job/status", 200
+        return job_status, endpoint, 200
         
     except Exception as e:
         logger.error(f"Error retrieving status for job {get_job_id}: {str(e)}")
-        return {"error": f"Failed to retrieve job status: {str(e)}"}, endpoint, 500 
+        return {"error": f"Failed to retrieve job status: {str(e)}"}, endpoint, 500


### PR DESCRIPTION
## Summary
- define `endpoint` variable in the job status route

## Testing
- `python -m py_compile $(git ls-files '*.py')`
